### PR TITLE
Predictors

### DIFF
--- a/models/base.py
+++ b/models/base.py
@@ -13,13 +13,17 @@ class BaseModel(object):
         self.cv = cv
         self.n_iter = n_iter
 
-    def fit(self, X, y):
-        """Train on a training set and select optimal hyperparameters."""
+    def impute(self, X):
         if X.isna().any().any():
             self.imputer = SimpleImputer(missing_values=np.nan, strategy='mean')
             X.loc[:, :] = self.imputer.fit_transform(X)
         else:
             self.imputer = None
+        return X
+
+    def fit(self, X, y):
+        """Train on a training set and select optimal hyperparameters."""
+        X = self.impute(X)
 
         if self.scaler is not None:
             X.loc[:, :] = self.scaler.fit_transform(X)
@@ -44,7 +48,7 @@ class BaseModel(object):
         return self.model.predict(X)
 
     def evaluate(self, X, y, metric):
-        y_hat = self.model.predict(X)
+        y_hat = self.predict(X)
         if metric not in metric_dict:
             raise ValueError(f"Metric {metric} not supported.")
         metric_fn = metric_dict[metric]

--- a/models/models.py
+++ b/models/models.py
@@ -22,6 +22,8 @@ class Lasso(BaseModel):
         self.scaler = StandardScaler()
 
     def fit(self, X, y):
+        X = self.impute(X)
+
         X.loc[:, :] = self.scaler.fit_transform(X)
 
         self.model.fit(X, y)

--- a/predictors/__init__.py
+++ b/predictors/__init__.py
@@ -1,0 +1,7 @@
+from .parse import parse_predictors
+from .check import check_predictors_present
+from .process import (
+    add_all_predictors,
+    process_wind_direction_predictor,
+    get_temporal_predictors
+)

--- a/predictors/all.txt
+++ b/predictors/all.txt
@@ -1,0 +1,2 @@
+temporal
+all

--- a/predictors/check.py
+++ b/predictors/check.py
@@ -1,0 +1,14 @@
+
+
+def check_predictors_present(data_set, predictor_subset):
+    """Check if all predictors in predictor_subset are present
+    as columns in the data_set dataframe."""
+    key_word_predictors = ['temporal', 'all']
+
+    for predictor in predictor_subset:
+        if (
+                predictor not in data_set.columns and
+                predictor not in key_word_predictors
+        ):
+            raise ValueError(f"Predictor {predictor} not found " +
+                                "in the data.")

--- a/predictors/knox.txt
+++ b/predictors/knox.txt
@@ -1,0 +1,5 @@
+temporal
+TA_F
+SW_IN_F
+WS_F
+PA_F

--- a/predictors/meteorological.txt
+++ b/predictors/meteorological.txt
@@ -1,0 +1,4 @@
+TA_F
+SW_IN_F
+WS_F
+PA_F

--- a/predictors/parse.py
+++ b/predictors/parse.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def parse_predictors(predictors_paths, predictors):
+    """Parse the predictors supplied through the command-line.
+
+    Args:
+        predictors_paths (list<str>): Comma-separated list path file(s) with
+                                      predictor names. See
+                                      predictors/metereological.txt for an
+                                      example.
+        predictors (list<str>): Comma-separated list of predictors. Ignored if
+                                predictors_path is provided.
+                                Certain keyword predictors are used to denote
+                                specific sets of predictors:
+                                ['temporal', 'all']
+
+    Return a dictionary mapping the name of each predictor subset to a list of
+    predictors.
+    """
+    if predictors_paths is not None:
+        if isinstance(predictors_paths, str):
+            predictors_paths = predictors_paths.split(",")
+        predictor_subsets = {}
+        for predictors_path in predictors_paths:
+            predictors_path = Path(predictors_path)
+            with predictors_path.open() as f:
+                predictor_subset = f.read().splitlines()
+            predictor_subsets[predictors_path.stem] = predictor_subset
+    elif predictors is not None:
+        if isinstance(predictors, str):
+            predictors = predictors.split(",")
+        predictor_subsets = {"predictors": predictors}
+    else:
+        raise ValueError("Must provide predictors or predictors_paths.")
+   
+    return predictor_subsets

--- a/predictors/process.py
+++ b/predictors/process.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pandas as pd
+
+
+def add_all_predictors(predictor_subset, columns):
+    """Add in all predictors in columns to predictor_subset."""
+    other_predictors = []
+    for predictor in columns:
+        if predictor not in predictor_subset and 'FCH4' not in predictor:
+           other_predictors.append(predictor)
+        elif predictor == 'FCH4':
+            continue
+        elif 'FCH4' in predictor:
+            print(f"Ignoring predictor {predictor}.")
+
+    predictor_subset += other_predictors
+    predictor_subset.remove('all')
+    
+    return predictor_subset
+
+
+def process_wind_direction_predictor(X):
+    X = X.copy()
+    X['WD'] = X['WD'] / 180 * np.pi
+    notna = ~X['WD'].isna()
+    X.loc[notna, 'WD_sin'] = np.sin(X.loc[notna, 'WD'])
+    X.loc[notna, 'WD_cos'] = np.cos(X.loc[notna, 'WD'])
+    X.drop('WD', axis=1, inplace=True)
+    return X
+
+
+def get_temporal_predictors(timestamp):
+    # add sinusoidal functions
+    timestamp = pd.to_datetime(timestamp, format='%Y%m%d%H%M').rename('delta')
+    doy = timestamp.dt.day
+    sin = np.sin(2 * np.pi * (doy - 1) / 365).rename('yearly_sin')
+    cos = np.cos(2 * np.pi * (doy - 1) / 365).rename('yearly_cos')
+
+    # add time deltas
+    delta = (timestamp - timestamp.iloc[0]) / pd.to_timedelta(1, unit='D')
+
+    return pd.concat([sin, cos, delta], axis=1)

--- a/predictors/temporal.txt
+++ b/predictors/temporal.txt
@@ -1,0 +1,1 @@
+temporal

--- a/train/train.py
+++ b/train/train.py
@@ -115,7 +115,7 @@ def train(
 
             if 'all' in predictor_subset:
                 predictor_subset = add_all_predictors(
-                    predictor_subset, train_set.columns
+                    predictor_subset, train_sets[0].columns
                 )
 
             use_temporal = 'temporal' in predictor_subset


### PR DESCRIPTION
**Problem**

There was no way of specifying keyword subsets of predictors, e.g. "temporal" or "all".

**Solution**

Implement predictor processing to handle keyword predictors. Also add predictor subset txt files corresponding to the manuscript and processing of wind direction. Finally, fix imputation bug.

**Tests**

```
python main.py train --sites NZKop --models [lasso,rf] --predictors_paths predictors/all.txt
python main.py train --sites MPM --models [lasso,rf] --predictors_paths predictors/all.txt
```

