### PR TITLE
Update process.py

### DIFF
--- a/fluxgapfill/predictors/process.py
+++ b/fluxgapfill/predictors/process.py
@@ -32,7 +32,7 @@ def process_wind_direction_predictor(X):
 def get_temporal_predictors(timestamp):
     # add sinusoidal functions
     timestamp = pd.to_datetime(timestamp, format='%Y%m%d%H%M').rename('delta')
-    doy = timestamp.dt.day
+    doy = timestamp.dt.dayofyear
     sin = np.sin(2 * np.pi * (doy - 1) / 365).rename('yearly_sin')
     cos = np.cos(2 * np.pi * (doy - 1) / 365).rename('yearly_cos')
 


### PR DESCRIPTION
fixed `doy` bug

**Problem**

`timestamp.dt.day` *returned the day of the month rather than the day of the year, and subsequently the sin/cos variables do not represent a yearly signal*

**Solution**

*replaced with* `timestamp.dt.day`

**Tests**

```python
>>> df = pd.DataFrame({'timestamp': [dt.datetime(2022, 12, 1)]})
>>> df['timestamp'].dt.day
0    1
Name: timestamp, dtype: int64
>>> df['timestamp'].dt.dayofyear
0    335
Name: timestamp, dtype: int64
```

